### PR TITLE
Use latest version of docker image instead of v1

### DIFF
--- a/mount-bitlocker
+++ b/mount-bitlocker
@@ -6,4 +6,4 @@ docker run --rm -it \
     --security-opt apparmor:unconfined \
     --device /dev/fuse \
     --device $DEVICE:/dev/bitlocker \
-    bitlocker-spi-toolkit:v1 $KEY
+    bitlocker-spi-toolkit:latest $KEY


### PR DESCRIPTION
The version v1 of the Docker image does not exist if following the steps described in the README.